### PR TITLE
fix: Deal with undetected timeZone in Stats.js

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -974,16 +974,22 @@ class Stats {
 		}
 		if (typeof obj.builtAt === "number") {
 			const builtAtDate = new Date(obj.builtAt);
+			let timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+			// Force UTC if runtime timezone could not be detected.
+			if (!timeZone || timeZone.toLowerCase() === "etc/unknown") {
+				timeZone = "UTC";
+			}
 			colors.normal("Built at: ");
 			colors.normal(
 				builtAtDate.toLocaleDateString(undefined, {
 					day: "2-digit",
 					month: "2-digit",
-					year: "numeric"
+					year: "numeric",
+					timeZone
 				})
 			);
 			colors.normal(" ");
-			colors.bold(builtAtDate.toLocaleTimeString());
+			colors.bold(builtAtDate.toLocaleTimeString(undefined, { timeZone }));
 			newline();
 		}
 		if (obj.env) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

As seen in https://github.com/facebook/create-react-app/issues/7783#issue-502900874 (and https://github.com/GoogleChrome/lighthouse/issues/1056 and others) if for some reasons the `timeZone` is undetected the locale-methods throw with "RangeError: Unsupported time zone specified undefined"

The issue itself was fixed in NodeJS 12, but affects other NodeJS LTS versions (6, 8, 10)

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This PR deals with the issue similar to https://github.com/GoogleChrome/lighthouse/pull/1086/files and https://github.com/GoogleChrome/lighthouse/pull/1086/files

**Did you add tests for your changes?**

This is bit tricky to test this as it needs OS level changes or ENV variable setup at launch but manual steps to test this is

```js
nvm install 10 # install affected version with nvm
nvm use 10 # checkout the node version
```

then reverse [this check](https://github.com/petetnt/webpack/pull/1/files#diff-baf371f5446dc9bc4b41022587e05b48R975) so that the locale time strings are run on the basic tests

```js
if (!typeof obj.builtAt === "number") {
```

then run the basic tests

```bash
yarn test:basic
```

See all the snapshot tests failing 👀 and then run the tests again with Etc/Unknown timezone

```
TZ=Etc/Unknown yarn test:basic
```

Expected:

- All the snapshot tests fail again 👀 

Actual:

```js
    RangeError: Unsupported time zone specified undefined
        at new DateTimeFormat (native)
        at Date.toLocaleDateString (native)
```

Apply the changes from this branch to confirm that the issue was fixed.

**Does this PR introduce a breaking change?**

Nope, it just fixes an unfortunate edge case

**What needs to be documented once your changes are merged?**

No need for doc changes
